### PR TITLE
マイページ質問一覧バグ修正/マイページ用質問ページ作成

### DIFF
--- a/app/Http/Controllers/ReactController.php
+++ b/app/Http/Controllers/ReactController.php
@@ -65,6 +65,14 @@ class ReactController extends Controller
     }
     
     /**
+     * マイページの質問データの受け渡し
+     */
+    public function getMyQuestion(Question $question)
+    {
+        return Comment::setComment($question);
+    }
+    
+    /**
      * 公開中の全質問受け渡し
      */
     public function getCheckedQuestions()

--- a/resources/js/components/Breadcrumbs.js
+++ b/resources/js/components/Breadcrumbs.js
@@ -22,6 +22,19 @@ function Breadcrumb(props){
             );
             break;
             
+        case "my_page_question":
+            link1 = (
+                <Link underline="hover" to="/my_page">
+                    マイページ
+                </Link>
+            );
+            link2 = (
+                <Typography color="text.primary">
+                    質問詳細
+                </Typography>
+            );
+            break;
+            
         case "history":
             link1 = (
                 <Link underline="hover" to="/my_page">

--- a/resources/js/components/Public/User/MyPage.js
+++ b/resources/js/components/Public/User/MyPage.js
@@ -121,7 +121,7 @@ function MyPage(props) {
                                                 }
                                             </TableCell>
                                             <TableCell key={question.id} align="left">
-                                                <Link to={ `/public/questions/` + question.id }>
+                                                <Link to={'/my_page/questions/' + question.id}>
                                                     { question.title.substring(0,50) + "..." }
                                                 </Link>
                                             </TableCell>

--- a/resources/js/components/Public/User/QuestionShow.js
+++ b/resources/js/components/Public/User/QuestionShow.js
@@ -1,0 +1,209 @@
+import React, {useState, useEffect} from 'react';
+import {useParams, useLocation} from 'react-router-dom';
+import axios from "axios";
+import Typography from '@material-ui/core/Typography';
+import Grid from '@mui/material/Grid';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+
+import Alert from '../../Alert';
+import Breadcrumbs from '../../Breadcrumbs';
+import Parameters from '../Question/Show/parameters';
+import Question from '../Question/Show/question';
+import Comments from '../Question/Show/comments/comments';
+import Documents from '../Question/Show/documents';
+import RelatedQuestions from '../Question/Show/related-questions';
+
+/**
+ * 質問詳細画面(マイページ)のメインコンポーネント
+ */
+function QuestionShow() {
+    const { id } = useParams();
+    const [screen_width, setScreenWidth] = useState(window.innerWidth);
+    const parameter = useLocation();
+    const [question, setQuestion] = useState([]);
+    const [documents, setDocuments] = useState([]);
+    const [related_questions, setRelatedQuestions] = useState([]);
+    const [user, setUser] = useState([]);
+    const [comment_changing, setCommentChanging] = useState(false);
+    const [question_changing, setQuestionChanging] = useState(false);
+    
+    // 画面幅を随時取得
+    window.addEventListener('resize', function() {
+        setScreenWidth(window.innerWidth);
+    });
+    
+    // 画面描画時に実行
+    useEffect(() => {
+        // 個別質問を取得
+        axios
+            .get(`/react/question/mypage/${ id }`)
+            .then(response => {
+                setQuestion(response.data);
+            }).catch(error => {
+                console.log(error);
+            });
+        
+        // 質問に関連する全参考記事を取得
+        axios
+            .get(`/react/documents/related/${ id }`)
+            .then(response => {
+                setDocuments(response.data);
+            }).catch(error => {
+                console.log(error);
+            });
+        
+        // ログインユーザ情報を取得
+        axios
+            .get("/react/user")
+            .then(response => {
+                setUser(response.data);
+            }).catch(error => {
+                console.log(error);
+            });
+    }, []);
+    
+    // useEffect(() => {
+    //     if (!(comment_changing)) {
+    //         // 個別質問を取得
+    //         axios
+    //             .get(`/react/question/checked/${ id }`)
+    //             .then(response => {
+    //                 setQuestion(response.data);
+    //             }).catch(error => {
+    //                 console.log(error);
+    //             });
+    //     }
+    // }, [comment_changing, question_changing]);
+    
+    useEffect(() => {
+        if (question) {
+        // この質問と同じカテゴリー、トピックの質問を取得
+        axios
+            .get(`/react/questions/search?category=${ question.category }&topic=${ question.topic }`)
+            .then(response => {
+                setRelatedQuestions(response.data);
+            }).catch(error => {
+                console.log(error);
+            });
+        }
+    }, [question]);
+    
+    const handleResolved = () => {
+        if (confirm('一度解決扱いにすると今後変更できません。\nよろしいですか？')) {
+            setQuestionChanging(true);
+            
+            axios
+                .post(`/questions/${ id }/resolved`)
+                .then(response => {
+                    if (response.status === 200) {
+                        setQuestionChanging(false);
+                    }
+                }).catch(error => {
+                    console.log(error);
+                });
+        } else {
+            window.alert('キャンセルしました');
+            return false;
+        }
+    };
+    
+    return (
+        <div className="container">
+            <Alert
+                type="question"
+                status={ parameter.state && parameter.state.question }
+                info={ parameter.state && parameter.state.number }
+            />
+            
+            <Breadcrumbs page="my_page_question"/>
+            
+            {question.check == 0 &&
+                <Typography component="div" align="center" color="error" sx={{ marginTop: 4, marginBottom: 3 }} >
+                    この質問は現在非公開中です
+                </Typography>
+            }
+            
+            { (question.length !== 0 && !(question.is_resolved) && (question.user_id === user.id || user.is_admin === 'staff')) &&
+                <Typography component="div" align="center" sx={{ marginTop: 4, marginBottom: 3 }} >
+                    <Button
+                        variant="contained"
+                        color="success"
+                        onClick={ handleResolved }
+                    >
+                        解決！！
+                    </Button>
+                </Typography>
+            }
+            
+            <Parameters 
+                category={ question.category }
+                topic={ question.topic }
+                curriculum_number={ question.curriculum_number }
+                is_resolved={ question.is_resolved }
+            />
+            
+            <Grid container spacing={2} sx={{ flexGrow: 1 }}>
+                <Grid
+                    item
+                    sx={{
+                        width: screen_width > 1000 ? "65%" : "100%"
+                    }}
+                >
+                    <Box>
+                        <Question
+                            title={ question.title }
+                            remarks={ question.remarks }
+                            updated_at={ question.updated_at }
+                            question={ question.question }
+                        />
+                        
+                        {question.check == 1 &&
+                        <React.Fragment>
+                            <Comments
+                                main_comments={ question.main_comments }
+                                sub_comments={ question.sub_comments }
+                                question_id={ id }
+                                setCommentChanging={ setCommentChanging }
+                                user_id={ user.id }
+                                is_admin={ user.is_admin }
+                            />
+                        
+                            <Typography
+                                variant="h4"
+                                component="div"
+                                align="center"
+                                sx={{
+                                    marginTop: 4,
+                                    marginBottom: 2,
+                                }}
+                            >
+                                参考記事
+                            </Typography>
+                        
+                            <Documents 
+                                documents={ documents }
+                            />
+                        </React.Fragment>
+                        }
+                    </Box>
+                </Grid>
+                
+                <Grid
+                    item
+                    sx={{
+                        width: screen_width > 1000 ? "35%" : "100%",
+                        minWidth: "300px"
+                    }}
+                >
+                    <RelatedQuestions 
+                        related_questions={ related_questions }
+                    />
+                </Grid>
+            </Grid>
+        </div>
+    );
+    
+}
+
+export default QuestionShow;

--- a/resources/js/components/Route.js
+++ b/resources/js/components/Route.js
@@ -6,6 +6,7 @@ import {BrowserRouter, Route, Switch} from 'react-router-dom';
 import Bar from './Layout/Bar';
 import AccessError from './Error';
 import MyPage from './Public/User/MyPage';
+import MyQuestion from './Public/User/QuestionShow';
 import History from './Public/History/History';
 import Home from './Public/Home/Home';
 import PublicDocumentIndex from './Public/Document/Index/Index';
@@ -62,6 +63,9 @@ function Router() {
                 
                 {/* ユーザマイページ表示 */}
                 <Route path="/my_page" exact component={ MyPage }/>
+                
+                {/* ユーザマイページ質問詳細表示 */}
+                <Route path="/my_page/questions/:id" exact component={ MyQuestion }/>
                 
                 {/* 質問履歴画面表示 */}
                 <Route path="/history" exact component={ History }/>

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,6 +53,7 @@ Route::group(['middleware' => ['auth']], function () {
      * 以下のurlはreact上で非同期通信として利用
      */
     Route::get('react/history', 'HomeController@getHistory'); // ログインユーザの閲覧した質問のデータ受け渡し
+    Route::get('react/question/mypage/{question}', 'ReactController@getMyQuestion'); // 公開中の個別質問データの受け渡し
     Route::get('react/question/checked/{question}', 'ReactController@getCheckedQuestion'); // 公開中の個別質問データの受け渡し
     Route::get('react/questions/checked', 'ReactController@getCheckedQuestions'); // 公開中の質問受け渡し
     Route::get('react/questions/search', 'ReactController@getSearchQuestions'); // 質問検索結果の受け渡し


### PR DESCRIPTION
・非公開の質問が取得できないため、非公開質問のみエラーが出ていた
　→ マイページ用の質問詳細ページを作成し、公開・非公開どちらも見れるように変更
・非公開質問はコメント、参考記事が表示されないように設定