### PR TITLE
Feature/add student info delete func

### DIFF
--- a/app/Console/Commands/DeleteGraduatesCommand.php
+++ b/app/Console/Commands/DeleteGraduatesCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\User;
+
+class DeleteGraduatesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:deleteGraduates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "delete graduate's data from users and students table.";
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        User::deleteGraduates();
+    }
+}

--- a/app/Student.php
+++ b/app/Student.php
@@ -3,10 +3,17 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use App\User;
+
 
 class Student extends Model
 {
     protected $fillable = [
         'name', 'password', 'user_id'
     ];
+    
+    public function user()
+    {
+        return $this->belongsTo('App\User');
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -51,6 +51,11 @@ class User extends Authenticatable
         return $this->belongsToMany('App\Question')->withPivot(['created_at'])->orderBy('pivot_created_at', 'desc');
     }
     
+    public function student()
+    {
+        return $this->hasOne('App\Student');
+    }
+    
     /**
      * 質問作成者名取得
      */
@@ -175,15 +180,10 @@ class User extends Authenticatable
     /**
      * 受講生情報をテーブルに追加
      */
-    public static function registerStudents(int $frag)
+    public static function registerStudents()
     {
         $date = new Carbon();
-        
-        if ($frag == 0) { // 未登録IDの受講生を追加
-            $datas = self::getUnRegisterApiData();
-        } else {
-            $datas = self::getStudentsApiData();
-        }
+        $datas = self::getUnRegisterApiData();
         
         // 受講生情報取得
         $students = $datas['values'];
@@ -205,6 +205,27 @@ class User extends Authenticatable
                     'password' => $password,
                     'user_id' => $user->id,
                 ]);
+            }
+        }
+    }
+    
+    public static function deleteGraduates()
+    {
+        // 4ヶ月前の年月を取得し、文字列のフォーマットを整える
+        $three_month_ago = new Carbon("-4 month");
+        $formated_year_and_month = $three_month_ago->format('ym');
+        $deletion_target = "ltcl" . $formated_year_and_month;
+        
+        $users_data = Self::get();
+
+        foreach($users_data as $user_data)
+        {
+            if(Hash::check($deletion_target, $user_data->password)){
+                $user_data->delete();
+                $user_data->student()->delete();
+                logger("data was deleted");
+            }else{
+                logger("doesn't match");   
             }
         }
     }


### PR DESCRIPTION
卒業生のデータを削除する機能を追加しました。
`php artisan command:deleteGraduates`を実行すれば、４ヶ月前に入学した学生のデータがusersテーブルとstudentsテーブルから削除されます。
ローカルでは動作確認済みですが、本番環境ではまだなので、マージしたら教えていただきたいです（herokuスケジューラーへの登録はまだです）。
