### PR TITLE
[update]ステータスを選択するセレクトボックスにラベルを追加

### DIFF
--- a/resources/js/components/Atom/Select/SelectStatus.js
+++ b/resources/js/components/Atom/Select/SelectStatus.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
 import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import axios from "axios";
@@ -35,7 +36,8 @@ const SelectStatus = React.memo(props => {
 
     return (
         <>
-            <FormControl sx={{ width: 115 }}>
+            <FormControl sx={{ width: 125 }}>
+                <InputLabel>ステータスを選ぶ</InputLabel>
                 <Select
                     onChange={e => handleChangeStatus(e)}
                     defaultValue={0}


### PR DESCRIPTION
修正前は、ラベルを設定していなかったため、セレクトボックスの外枠が途切れていた。