### PR TITLE
[fix]認証突破後にjs/index.js.mapへリダイレクトするエラーへの対処

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\RedirectIfIndexJsMap::class
     ];
 
     /**

--- a/app/Http/Middleware/RedirectIfIndexJsMap.php
+++ b/app/Http/Middleware/RedirectIfIndexJsMap.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class RedirectIfIndexJsMap
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if ($request->path() === 'js/index.js.map') {
+            return redirect('/');
+        }
+        return $next($request);
+    }
+}


### PR DESCRIPTION
ミドルウェアを追加して、js/index.js.mapに遷移した際、強制的に/へリダイレクトするように変更しました。